### PR TITLE
gh-29 Use standard logging facility for 5.3 Module

### DIFF
--- a/coherence-hibernate-cache-53/pom.xml
+++ b/coherence-hibernate-cache-53/pom.xml
@@ -46,6 +46,17 @@
             <version>2.1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.oracle.coherence.hibernate</groupId>
             <artifactId>coherence-hibernate-cache-core</artifactId>
             <version>2.1.0-SNAPSHOT</version>

--- a/coherence-hibernate-cache-53/src/main/java/com/oracle/coherence/hibernate/cache/v53/access/AbstractCoherenceEntityDataAccess.java
+++ b/coherence-hibernate-cache-53/src/main/java/com/oracle/coherence/hibernate/cache/v53/access/AbstractCoherenceEntityDataAccess.java
@@ -14,10 +14,11 @@ import org.hibernate.cache.spi.support.AbstractDomainDataRegion;
 import org.hibernate.cache.spi.support.DomainDataStorageAccess;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 
-import com.oracle.coherence.hibernate.cache.v53.CoherenceRegionFactory;
 import com.oracle.coherence.hibernate.cache.v53.access.processor.PutFromLoadProcessor;
 import com.oracle.coherence.hibernate.cache.v53.region.CoherenceRegion;
 import com.oracle.coherence.hibernate.cache.v53.region.CoherenceRegionValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Comparator;
 import java.util.UUID;
@@ -33,6 +34,7 @@ import java.util.concurrent.atomic.AtomicLong;
 abstract class AbstractCoherenceEntityDataAccess
 {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractCoherenceEntityDataAccess.class);
 
     // ---- Constants
 
@@ -80,7 +82,10 @@ abstract class AbstractCoherenceEntityDataAccess
      */
     public AbstractCoherenceEntityDataAccess(DomainDataRegion domainDataRegion, DomainDataStorageAccess storageAccess, Comparator<?> versionComparator)
     {
-        debugf("%s", getClass().getName());
+        if (LOGGER.isDebugEnabled())
+        {
+            LOGGER.debug("Constructing AbstractCoherenceEntityDataAccess.");
+        }
         this.domainDataRegion = domainDataRegion;
         this.storageAccess = storageAccess;
         this.versionComparator = versionComparator;
@@ -161,7 +166,10 @@ abstract class AbstractCoherenceEntityDataAccess
      */
     public Object get(SharedSessionContractImplementor session, Object key) throws CacheException
     {
-        debugf("%s.getValue(%s)", this, key);
+        if (LOGGER.isDebugEnabled())
+        {
+            LOGGER.debug("getValue({})", key);
+        }
         CoherenceRegionValue cacheValue = (CoherenceRegionValue) getCoherenceRegion().getValue(key);
         return (cacheValue == null)? null : cacheValue.getValue();
     }
@@ -172,7 +180,10 @@ abstract class AbstractCoherenceEntityDataAccess
     public boolean putFromLoad(SharedSessionContractImplementor session, Object key, Object value, Object version)
     throws CacheException
     {
-        debugf("%s.putFromLoad(%s, %s, %s)", this, key, value, version);
+        if (LOGGER.isDebugEnabled())
+        {
+            LOGGER.debug("putFromLoad({}, {}, {})", key, value, version);
+        }
         return putFromLoad(session, key, value, version, this.getCoherenceRegion().getRegionFactory().isMinimalPutsEnabledByDefault()); //TODO
     }
 
@@ -182,7 +193,10 @@ abstract class AbstractCoherenceEntityDataAccess
     public boolean putFromLoad(SharedSessionContractImplementor session, Object key, Object value, Object version, boolean minimalPutOverride)
     throws CacheException
     {
-        debugf("%s.putFromLoad(%s, %s, %s, %s)", this, key, value, version, minimalPutOverride);
+        if (LOGGER.isDebugEnabled())
+        {
+            LOGGER.debug("putFromLoad({}, {}, {}, {})", key, value, version, minimalPutOverride);
+        }
         CoherenceRegionValue newCacheValue = newCacheValue(value, version);
         PutFromLoadProcessor processor = new PutFromLoadProcessor(minimalPutOverride, newCacheValue);
         return (Boolean) getCoherenceRegion().invoke(key, processor);
@@ -194,7 +208,10 @@ abstract class AbstractCoherenceEntityDataAccess
      */
     public SoftLock lockItem(SharedSessionContractImplementor session, Object key, Object version) throws CacheException
     {
-        debugf("%s.lockItem(%s, %s)", this, key, version);
+        if (LOGGER.isDebugEnabled())
+        {
+            LOGGER.debug("lockItem({}, {})", key, version);
+        }
         //for the majority of access strategies lockItem is a no-op
         return null;
     }
@@ -204,7 +221,10 @@ abstract class AbstractCoherenceEntityDataAccess
      */
     public SoftLock lockRegion() throws CacheException
     {
-        debugf("%s.lockRegion()", this);
+        if (LOGGER.isDebugEnabled())
+        {
+            LOGGER.debug("lockRegion()");
+        }
         getCoherenceRegion().lockCache();
         return null;
     }
@@ -214,7 +234,10 @@ abstract class AbstractCoherenceEntityDataAccess
      */
     public void unlockItem(SharedSessionContractImplementor session, Object key, SoftLock lock) throws CacheException
     {
-        debugf("%s.lockItem(%s, %s)", this, key, lock);
+        if (LOGGER.isDebugEnabled())
+        {
+            LOGGER.debug("lockItem({}, {})", key, lock);
+        }
         //for the majority of access strategies unlockItem is a no-op
     }
 
@@ -223,7 +246,10 @@ abstract class AbstractCoherenceEntityDataAccess
      */
     public void unlockRegion(SoftLock lock) throws CacheException
     {
-        debugf("%s.unlockRegion(%s)", this, lock);
+        if (LOGGER.isDebugEnabled())
+        {
+            LOGGER.debug("unlockRegion({})", lock);
+        }
         getCoherenceRegion().unlockCache();
     }
 
@@ -232,7 +258,10 @@ abstract class AbstractCoherenceEntityDataAccess
      */
     public void remove(SharedSessionContractImplementor session, Object key) throws CacheException
     {
-        debugf("%s.remove(%s)", this, key);
+        if (LOGGER.isDebugEnabled())
+        {
+            LOGGER.debug("remove({})", key);
+        }
         evict(key);
     }
 
@@ -241,7 +270,10 @@ abstract class AbstractCoherenceEntityDataAccess
      */
     public void removeAll(SharedSessionContractImplementor session) throws CacheException
     {
-        debugf("%s.removeAll()", this);
+        if (LOGGER.isDebugEnabled())
+        {
+            LOGGER.debug("removeAll()");
+        }
         evictAll();
     }
 
@@ -250,7 +282,10 @@ abstract class AbstractCoherenceEntityDataAccess
      */
     public void evict(Object key) throws CacheException
     {
-        debugf("%s.evict(%s)", this, key);
+        if (LOGGER.isDebugEnabled())
+        {
+            LOGGER.debug("evict({})", key);
+        }
         getCoherenceRegion().evict(key);
     }
 
@@ -259,7 +294,10 @@ abstract class AbstractCoherenceEntityDataAccess
      */
     public void evictAll() throws CacheException
     {
-        debugf("%s.evictAll()", this);
+        if (LOGGER.isDebugEnabled())
+        {
+            LOGGER.debug("evictAll()");
+        }
         getCoherenceRegion().evictAll();
     }
 
@@ -277,19 +315,6 @@ abstract class AbstractCoherenceEntityDataAccess
     protected CoherenceRegionValue newCacheValue(Object value, Object version)
     {
         return new CoherenceRegionValue(value, version, getCoherenceRegion().nextTimestamp());
-    }
-
-    // ---- Internal: logging support
-
-    /**
-     * Log the argument message with formatted arguments at debug severity
-     *
-     * @param message the message to log
-     * @param arguments the arguments to the format specifiers in message
-     */
-    protected void debugf(String message, Object ... arguments)
-    {
-        CoherenceRegionFactory.debugf(message, arguments);
     }
 
     public boolean contains(Object key) {

--- a/coherence-hibernate-cache-53/src/main/java/com/oracle/coherence/hibernate/cache/v53/access/AbstractReadWriteCoherenceEntityDataAccess.java
+++ b/coherence-hibernate-cache-53/src/main/java/com/oracle/coherence/hibernate/cache/v53/access/AbstractReadWriteCoherenceEntityDataAccess.java
@@ -19,6 +19,8 @@ import com.oracle.coherence.hibernate.cache.v53.access.processor.ReadWritePutFro
 import com.oracle.coherence.hibernate.cache.v53.access.processor.SoftLockItemProcessor;
 import com.oracle.coherence.hibernate.cache.v53.access.processor.SoftUnlockItemProcessor;
 import com.oracle.coherence.hibernate.cache.v53.region.CoherenceRegionValue;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Comparator;
 
@@ -33,14 +35,16 @@ abstract class AbstractReadWriteCoherenceEntityDataAccess
 extends AbstractCoherenceEntityDataAccess
 {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractReadWriteCoherenceEntityDataAccess.class);
 
     // ---- Constructors
 
     /**
      * Complete constructor.
      *
-     * @param coherenceRegion the CoherenceRegion for this AbstractReadWriteCoherenceEntityDataAccess
-     * @param sessionFactoryOptions the Hibernate SessionFactoryOptions object
+     * @param domainDataRegion the CoherenceRegion for this AbstractReadWriteCoherenceEntityDataAccess
+     * @param domainDataStorageAccess the Hibernate SessionFactoryOptions object
+     * @param versionComparator
      */
     public AbstractReadWriteCoherenceEntityDataAccess(DomainDataRegion domainDataRegion,
             DomainDataStorageAccess domainDataStorageAccess, Comparator<?> versionComparator)
@@ -57,7 +61,10 @@ extends AbstractCoherenceEntityDataAccess
     @Override
     public Object get(SharedSessionContractImplementor session, Object key) throws CacheException
     {
-        debugf("%s.get(%s)", this, key);
+        if (LOGGER.isDebugEnabled())
+        {
+            LOGGER.debug("get({})", key);
+        }
         return getCoherenceRegion().invoke(key, new GetProcessor());
     }
 
@@ -67,7 +74,10 @@ extends AbstractCoherenceEntityDataAccess
     @Override
     public org.hibernate.cache.spi.access.SoftLock lockItem(SharedSessionContractImplementor session, Object key, Object version) throws CacheException
     {
-        debugf("%s.lockItem(%s, %s)", this, key, version);
+        if (LOGGER.isDebugEnabled())
+        {
+            LOGGER.debug("lockItem({}, {})", key, version);
+        }
         CoherenceRegionValue valueIfAbsent = newCacheValue(null, version);
         CoherenceRegionValue.SoftLock newSoftLock = newSoftLock();
         SoftLockItemProcessor processor = new SoftLockItemProcessor(valueIfAbsent, newSoftLock);
@@ -82,7 +92,10 @@ extends AbstractCoherenceEntityDataAccess
     public boolean putFromLoad(SharedSessionContractImplementor session, Object key, Object value, Object version, boolean minimalPutOverride)
     throws CacheException
     {
-        debugf("%s.putFromLoad(%s, %s, %s, %s)", this, key, value, version, minimalPutOverride);
+        if (LOGGER.isDebugEnabled())
+        {
+            LOGGER.debug("putFromLoad({}, {}, {}, {})", key, value, version, minimalPutOverride);
+        }
         CoherenceRegionValue newCacheValue = newCacheValue(value, version);
         ReadWritePutFromLoadProcessor processor = new ReadWritePutFromLoadProcessor(minimalPutOverride, this.getCoherenceRegion().nextTimestamp(), newCacheValue, super.getVersionComparator());
         return (Boolean) getCoherenceRegion().invoke(key, processor);
@@ -94,7 +107,10 @@ extends AbstractCoherenceEntityDataAccess
     @Override
     public void unlockItem(SharedSessionContractImplementor session, Object key, org.hibernate.cache.spi.access.SoftLock lock) throws CacheException
     {
-        debugf("%s.unlockItem(%s, %s)", this, key, lock);
+        if (LOGGER.isDebugEnabled())
+        {
+            LOGGER.debug("unlockItem({}, {})", key, lock);
+        }
         SoftUnlockItemProcessor processor = new SoftUnlockItemProcessor(lock, getCoherenceRegion().nextTimestamp());
         getCoherenceRegion().invoke(key, processor);
     }

--- a/coherence-hibernate-cache-53/src/main/java/com/oracle/coherence/hibernate/cache/v53/access/CoherenceNonstrictReadWriteEntityAccess.java
+++ b/coherence-hibernate-cache-53/src/main/java/com/oracle/coherence/hibernate/cache/v53/access/CoherenceNonstrictReadWriteEntityAccess.java
@@ -18,6 +18,8 @@ import org.hibernate.cache.spi.support.DomainDataStorageAccess;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.persister.entity.EntityPersister;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A CoherenceNonstrictReadWriteEntityAccess is an AbstractCoherenceEntityDataAccess
@@ -30,6 +32,8 @@ public class CoherenceNonstrictReadWriteEntityAccess
 extends AbstractCoherenceEntityDataAccess
 implements EntityDataAccess
 {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CoherenceNonstrictReadWriteEntityAccess.class);
 
 
     // ---- Constructors
@@ -60,7 +64,10 @@ implements EntityDataAccess
         //Hibernate will make the call sequence insert() -> afterInsert() when inserting an entity.
         //"Synchronous" (i.e. transactional) access strategies should insert the cache entry here, but
         //"asynchrononous" (i.e. non-transactional) strategies should insert it in afterInsert instead.
-        debugf("%s.insert(%s, %s, %s)", this, key, value, version);
+        if (LOGGER.isDebugEnabled())
+        {
+            LOGGER.debug("insert({}, {}, {})", key, value, version);
+        }
         return false;
     }
 
@@ -75,7 +82,10 @@ implements EntityDataAccess
         //"Asynchrononous" (i.e. non-transactional) strategies should insert the cache entry here.
         //But in nonstrict-read-write cache concurrency strategies, don't put newly inserted entities, to force
         //subsequent putFromLoad.
-        debugf("%s.afterInsert(%s, %s, %s)", this, key, value, version);
+        if (LOGGER.isDebugEnabled())
+        {
+            LOGGER.debug("afterInsert({}, {}, {})", key, value, version);
+        }
         return false;
     }
 
@@ -89,7 +99,10 @@ implements EntityDataAccess
         //Hibernate will make the call sequence lockItem() -> update() -> afterUpdate() when updating an entity.
         //"Synchronous" (i.e. transactional) access strategies should update the cache entry here, but
         //"asynchrononous" (i.e. non-transactional) strategies should update it in afterUpdate instead.
-        debugf("%s.update(%s, %s, %s, %s)", this, key, value, currentVersion, previousVersion);
+        if (LOGGER.isDebugEnabled())
+        {
+            LOGGER.debug("update({}, {}, {}, {})", key, value, currentVersion, previousVersion);
+        }
         return false;
     }
 
@@ -106,7 +119,10 @@ implements EntityDataAccess
         //"Asynchrononous" (i.e. non-transactional) strategies should invalidate or update the cache entry here and release the lock,
         //as appropriate for the kind of strategy (nonstrict-read-write vs. read-write).
         //In the nonstrict-read-write strategy we remove the cache entry to force subsequent putFromLoad.
-        debugf("%s.afterUpdate(%s, %s, %s, %s, %s)", this, key, value, currentVersion, previousVersion, lock);
+        if (LOGGER.isDebugEnabled())
+        {
+            LOGGER.debug("afterUpdate({}, {}, {}, {}, {})", key, value, currentVersion, previousVersion, lock);
+        }
         remove(session, key);
         unlockItem(session, key, lock);
         return false;

--- a/coherence-hibernate-cache-53/src/main/java/com/oracle/coherence/hibernate/cache/v53/access/CoherenceNonstrictReadWriteNaturalIdAccess.java
+++ b/coherence-hibernate-cache-53/src/main/java/com/oracle/coherence/hibernate/cache/v53/access/CoherenceNonstrictReadWriteNaturalIdAccess.java
@@ -14,6 +14,8 @@ import org.hibernate.cache.spi.access.SoftLock;
 import org.hibernate.cache.spi.support.DomainDataStorageAccess;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.persister.entity.EntityPersister;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A CoherenceNonstrictReadWriteNaturalIdAccess is a CoherenceRegionAccessStrategy
@@ -27,6 +29,7 @@ extends AbstractCoherenceEntityDataAccess
 implements NaturalIdDataAccess
 {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(CoherenceNonstrictReadWriteNaturalIdAccess.class);
 
     // ---- Constructors
 
@@ -55,7 +58,10 @@ implements NaturalIdDataAccess
         //Hibernate will make the call sequence insert() -> afterInsert() when inserting a natural ID.
         //"Synchronous" (i.e. transactional) access strategies should insert the cache entry here, but
         //"asynchrononous" (i.e. non-transactional) strategies should insert it in afterInsert instead.
-        debugf("%s.insert(%s, %s)", this, key, value);
+        if (LOGGER.isDebugEnabled())
+        {
+            LOGGER.debug("insert({}, {})", key, value);
+        }
         return false;
     }
 
@@ -70,7 +76,10 @@ implements NaturalIdDataAccess
         //"Asynchrononous" (i.e. non-transactional) strategies should insert the cache entry here.
         //But in nonstrict-read-write cache concurrency strategies, don't put newly inserted natural IDs, to force
         //subsequent putFromLoad.
-        debugf("%s.afterInsert(%s, %s)", this, key, value);
+        if (LOGGER.isDebugEnabled())
+        {
+            LOGGER.debug("afterInsert({}, {})", key, value);
+        }
         return false;
     }
 
@@ -84,7 +93,10 @@ implements NaturalIdDataAccess
         //Hibernate will make the call sequence lockItem() -> remove() -> update() -> afterUpdate() when updating a natural ID.
         //"Synchronous" (i.e. transactional) access strategies should update the cache entry here, but
         //"asynchrononous" (i.e. non-transactional) strategies should update it in afterUpdate instead.
-        debugf("%s.update(%s, %s, %s, %s)", this, key, value);
+        if (LOGGER.isDebugEnabled())
+        {
+            LOGGER.debug("update({}, {})", key, value);
+        }
         return false;
     }
 
@@ -99,7 +111,10 @@ implements NaturalIdDataAccess
         //"Asynchrononous" (i.e. non-transactional) strategies should invalidate or update the cache entry here and release the lock,
         //as appropriate for the kind of strategy (nonstrict-read-write vs. read-write).
         //In the nonstrict-read-write strategy we remove the cache entry to force subsequent putFromLoad.
-        debugf("%s.afterUpdate(%s, %s, %s)", this, key, value, lock);
+        if (LOGGER.isDebugEnabled())
+        {
+            LOGGER.debug("afterUpdate({}, {}, {})", key, value, lock);
+        }
         remove(session, key);
         unlockItem(session, key, lock);
         return false;

--- a/coherence-hibernate-cache-53/src/main/java/com/oracle/coherence/hibernate/cache/v53/access/CoherenceReadOnlyEntityAccess.java
+++ b/coherence-hibernate-cache-53/src/main/java/com/oracle/coherence/hibernate/cache/v53/access/CoherenceReadOnlyEntityAccess.java
@@ -18,6 +18,8 @@ import org.hibernate.cache.spi.support.DomainDataStorageAccess;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.persister.entity.EntityPersister;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * An CoherenceReadOnlyEntityAccess is an AbstractCoherenceEntityDataAccess
@@ -31,6 +33,7 @@ extends AbstractCoherenceEntityDataAccess
 implements EntityDataAccess
 {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(CoherenceReadOnlyEntityAccess.class);
 
     // ---- Constructors
 
@@ -59,7 +62,10 @@ implements EntityDataAccess
         //Hibernate will make the call sequence insert() -> afterInsert() when inserting an entity.
         //"Synchronous" (i.e. transactional) access strategies should insert the cache entry here, but
         //"asynchrononous" (i.e. non-transactional) strategies should insert it in afterInsert instead.
-        debugf("%s.insert(%s, %s, %s)", this, key, value, version);
+        if (LOGGER.isDebugEnabled())
+        {
+            LOGGER.debug("insert({}, {}, {})", key, value, version);
+        }
         return false;
     }
 
@@ -72,7 +78,10 @@ implements EntityDataAccess
         //per http://docs.jboss.org/hibernate/orm/4.1/javadocs/org/hibernate/cache/spi/access/EntityRegionAccessStrategy.html,
         //Hibernate will make the call sequence insert() -> afterInsert() when inserting an entity.
         //"Asynchrononous" (i.e. non-transactional) strategies should insert the cache entry here.
-        debugf("%s.afterInsert(%s, %s, %s)", getClass().getName(), key, value, version);
+        if (LOGGER.isDebugEnabled())
+        {
+            LOGGER.debug("afterInsert({}, {}, {})", key, value, version);
+        }
         getCoherenceRegion().putValue(key, newCacheValue(value, version));
         return true;
     }
@@ -84,7 +93,10 @@ implements EntityDataAccess
     public boolean update(SharedSessionContractImplementor session, Object key, Object value, Object currentVersion, Object previousVersion) throws CacheException
     {
         //read-only cache entries should not be updated
-        debugf("%s.update(%s, %s, %s, %s)", this, key, value, currentVersion, previousVersion);
+        if (LOGGER.isDebugEnabled())
+        {
+            LOGGER.debug("update({}, {}, {}, {})", key, value, currentVersion, previousVersion);
+        }
         throw new UnsupportedOperationException(WRITE_OPERATIONS_NOT_SUPPORTED_MESSAGE);
     }
 
@@ -95,7 +107,10 @@ implements EntityDataAccess
     public boolean afterUpdate(SharedSessionContractImplementor session, Object key, Object value, Object currentVersion, Object previousVersion, SoftLock lock) throws CacheException
     {
         //read-only cache entries should not be updated
-        debugf("%s.afterUpdate(%s, %s, %s, %s, %s)", this, key, value, currentVersion, previousVersion, lock);
+        if (LOGGER.isDebugEnabled())
+        {
+            LOGGER.debug("afterUpdate({}, {}, {}, {}, {})", key, value, currentVersion, previousVersion, lock);
+        }
         throw new UnsupportedOperationException(WRITE_OPERATIONS_NOT_SUPPORTED_MESSAGE);
     }
 

--- a/coherence-hibernate-cache-53/src/main/java/com/oracle/coherence/hibernate/cache/v53/access/CoherenceReadOnlyNaturalIdAccess.java
+++ b/coherence-hibernate-cache-53/src/main/java/com/oracle/coherence/hibernate/cache/v53/access/CoherenceReadOnlyNaturalIdAccess.java
@@ -14,6 +14,8 @@ import org.hibernate.cache.spi.access.SoftLock;
 import org.hibernate.cache.spi.support.DomainDataStorageAccess;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.persister.entity.EntityPersister;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A CoherenceReadOnlyNaturalIdAccess is a CoherenceRegionAccessStrategy
@@ -27,6 +29,7 @@ extends AbstractCoherenceEntityDataAccess
 implements NaturalIdDataAccess
 {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(CoherenceReadOnlyNaturalIdAccess.class);
 
     // ---- Constructors
 
@@ -55,7 +58,10 @@ implements NaturalIdDataAccess
         //Hibernate will make the call sequence insert() -> afterInsert() when inserting an entity.
         //"Synchronous" (i.e. transactional) access strategies should insert the cache entry here, but
         //"asynchrononous" (i.e. non-transactional) strategies should insert it in afterInsert instead.
-        debugf("%s.insert(%s, %s)", this, key, value);
+        if (LOGGER.isDebugEnabled())
+        {
+            LOGGER.debug("insert({}, {})", key, value);
+        }
         return false;
     }
 
@@ -68,7 +74,10 @@ implements NaturalIdDataAccess
         //per http://docs.jboss.org/hibernate/orm/4.1/javadocs/org/hibernate/cache/spi/access/NaturalIdRegionAccessStrategy.html,
         //Hibernate will make the call sequence insert() -> afterInsert() when inserting an entity.
         //"Asynchrononous" (i.e. non-transactional) strategies should insert the cache entry here.
-        debugf("%s.afterInsert(%s, %s)", getClass().getName(), key, value);
+        if (LOGGER.isDebugEnabled())
+        {
+            LOGGER.debug("afterInsert({}, {})", key, value);
+        }
         getCoherenceRegion().putValue(key, newCacheValue(value, null));
         return true;
     }
@@ -80,7 +89,10 @@ implements NaturalIdDataAccess
     public boolean update(SharedSessionContractImplementor session, Object key, Object value) throws CacheException
     {
         //read-only cache entries should not be updated
-        debugf("%s.update(%s, %s)", this, key, value);
+        if (LOGGER.isDebugEnabled())
+        {
+            LOGGER.debug("update({}, {})", key, value);
+        }
         throw new UnsupportedOperationException(WRITE_OPERATIONS_NOT_SUPPORTED_MESSAGE);
     }
 
@@ -91,7 +103,10 @@ implements NaturalIdDataAccess
     public boolean afterUpdate(SharedSessionContractImplementor session, Object key, Object value, SoftLock lock) throws CacheException
     {
         //read-only cache entries should not be updated
-        debugf("%s.afterUpdate(%s, %s, %s)", this, key, value, lock);
+        if (LOGGER.isDebugEnabled())
+        {
+            LOGGER.debug("afterUpdate({}, {}, {})", key, value, lock);
+        }
         throw new UnsupportedOperationException(WRITE_OPERATIONS_NOT_SUPPORTED_MESSAGE);
     }
 

--- a/coherence-hibernate-cache-53/src/main/java/com/oracle/coherence/hibernate/cache/v53/access/CoherenceReadWriteEntityAccess.java
+++ b/coherence-hibernate-cache-53/src/main/java/com/oracle/coherence/hibernate/cache/v53/access/CoherenceReadWriteEntityAccess.java
@@ -18,6 +18,8 @@ import org.hibernate.cache.spi.support.DomainDataStorageAccess;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.persister.entity.EntityPersister;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * An CoherenceReadWriteEntityAccess is a Coherence-based read-write region access strategy
@@ -31,6 +33,7 @@ extends AbstractReadWriteCoherenceEntityDataAccess
 implements EntityDataAccess
 {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(EntityDataAccess.class);
 
     // ---- Constructors
 
@@ -70,7 +73,10 @@ implements EntityDataAccess
         //Hibernate will make the call sequence insert() -> afterInsert() when inserting an entity.
         //"Synchronous" (i.e. transactional) access strategies should insert the cache entry here, but
         //"asynchrononous" (i.e. non-transactional) strategies should insert it in afterInsert instead.
-        debugf("%s.insert(%s, %s, %s)", this, key, value, version);
+        if (LOGGER.isDebugEnabled())
+        {
+            LOGGER.debug("insert({}, {}, {})", key, value, version);
+        }
         return false;
     }
 
@@ -84,7 +90,10 @@ implements EntityDataAccess
         //Hibernate will make the call sequence insert() -> afterInsert() when inserting an entity.
         //"Asynchrononous" (i.e. non-transactional) strategies should insert the cache entry here.
         //In implementation we only insert the entry if there was no entry already present at the argument key
-        debugf("%s.afterInsert(%s, %s, %s)", this, key, value, version);
+        if (LOGGER.isDebugEnabled())
+        {
+            LOGGER.debug("insert({}, {}, {})", key, value, version);
+        }
         return super.afterInsert(key, newCacheValue(value, version));
     }
 
@@ -98,7 +107,10 @@ implements EntityDataAccess
         //Hibernate will make the call sequence lockItem() -> update() -> afterUpdate() when updating an entity.
         //"Synchronous" (i.e. transactional) access strategies should update the cache entry here, but
         //"asynchrononous" (i.e. non-transactional) strategies should update it in afterUpdate instead.
-        debugf("%s.update(%s, %s, %s, %s)", this, key, value, currentVersion, previousVersion);
+        if (LOGGER.isDebugEnabled())
+        {
+            LOGGER.debug("insert({}, {}, {}, {})", key, value, currentVersion, previousVersion);
+        }
         return false;
     }
 
@@ -113,7 +125,10 @@ implements EntityDataAccess
         //"Asynchrononous" (i.e. non-transactional) strategies should invalidate or update the cache entry here and release the lock,
         //as appropriate for the kind of strategy (nonstrict-read-write vs. read-write).
         //In the read-write strategy we only update the cache value if it is present and was not multiply locked.
-        debugf("%s.afterUpdate(%s, %s, %s)", this, key, value, currentVersion, previousVersion, lock);
+        if (LOGGER.isDebugEnabled())
+        {
+            LOGGER.debug("afterUpdate({}, {}, {}, {}, {})", key, value, currentVersion, previousVersion, lock);
+        }
         return afterUpdate(key, newCacheValue(value, currentVersion), lock);
     }
 

--- a/coherence-hibernate-cache-53/src/main/java/com/oracle/coherence/hibernate/cache/v53/access/CoherenceReadWriteNaturalIdAccess.java
+++ b/coherence-hibernate-cache-53/src/main/java/com/oracle/coherence/hibernate/cache/v53/access/CoherenceReadWriteNaturalIdAccess.java
@@ -14,6 +14,8 @@ import org.hibernate.cache.spi.access.SoftLock;
 import org.hibernate.cache.spi.support.DomainDataStorageAccess;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.persister.entity.EntityPersister;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A CoherenceReadWriteNaturalIdAccess is a Coherence-based read-write region access strategy
@@ -27,6 +29,7 @@ extends AbstractReadWriteCoherenceEntityDataAccess
 implements NaturalIdDataAccess
 {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(CoherenceReadWriteNaturalIdAccess.class);
 
     // ---- Constructors
 
@@ -65,7 +68,10 @@ implements NaturalIdDataAccess
         //Hibernate will make the call sequence insert() -> afterInsert() when inserting a natural ID.
         //"Synchronous" (i.e. transactional) access strategies should insert the cache entry here, but
         //"asynchrononous" (i.e. non-transactional) strategies should insert it in afterInsert instead.
-        debugf("%s.insert(%s, %s)", this, key, value);
+        if (LOGGER.isDebugEnabled())
+        {
+            LOGGER.debug("insert - key: {}, value: {}",key, value);
+        }
         return false;
     }
 
@@ -79,7 +85,10 @@ implements NaturalIdDataAccess
         //Hibernate will make the call sequence insert() -> afterInsert() when inserting a natural ID.
         //"Asynchrononous" (i.e. non-transactional) strategies should insert the cache entry here.
         //In implementation we only insert the entry if there was no entry already present at the argument key
-        debugf("%s.afterInsert(%s, %s)", this, key, value);
+        if (LOGGER.isDebugEnabled())
+        {
+            LOGGER.debug("afterInsert({}, {})", key, value);
+        }
         return afterInsert(key, newCacheValue(value, null));
     }
 
@@ -93,7 +102,10 @@ implements NaturalIdDataAccess
         //Hibernate will make the call sequence lockItem() -> remove() -> update() -> afterUpdate() when updating a natural ID.
         //"Synchronous" (i.e. transactional) access strategies should update the cache entry here, but
         //"asynchrononous" (i.e. non-transactional) strategies should update it in afterUpdate instead.
-        debugf("%s.update(%s, %s, %s, %s)", this, key, value);
+        if (LOGGER.isDebugEnabled())
+        {
+            LOGGER.debug("update({}, {})",key, value);
+        }
         return false;
     }
 
@@ -108,7 +120,10 @@ implements NaturalIdDataAccess
         //"Asynchrononous" (i.e. non-transactional) strategies should invalidate or update the cache entry here and release the lock,
         //as appropriate for the kind of strategy (nonstrict-read-write vs. read-write).
         //In the read-write strategy we only update the cache value if it is present and was not multiply locked.
-        debugf("%s.afterUpdate(%s, %s, %s)", this, key, value, lock);
+        if (LOGGER.isDebugEnabled())
+        {
+            LOGGER.debug("afterUpdate({}, {}, {})", key, value, lock);
+        }
         return afterUpdate(key, newCacheValue(value, null), lock);
     }
 

--- a/coherence-hibernate-cache-53/src/main/java/com/oracle/coherence/hibernate/cache/v53/configuration/support/Assert.java
+++ b/coherence-hibernate-cache-53/src/main/java/com/oracle/coherence/hibernate/cache/v53/configuration/support/Assert.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ * https://oss.oracle.com/licenses/upl.
+ */
+package com.oracle.coherence.hibernate.cache.v53.configuration.support;
+
+/**
+ * Helper class for some common assertions.
+ * @author Gunnar Hillert
+ * @since 2.1
+ */
+public abstract class Assert {
+
+	private Assert() {
+		throw new AssertionError();
+	}
+
+	public static void notNull(Object object, String message) {
+		if (object == null) {
+			throw new IllegalArgumentException(message);
+		}
+	}
+}

--- a/coherence-hibernate-cache-53/src/main/java/com/oracle/coherence/hibernate/cache/v53/configuration/support/CoherenceHibernateSystemPropertyResolver.java
+++ b/coherence-hibernate-cache-53/src/main/java/com/oracle/coherence/hibernate/cache/v53/configuration/support/CoherenceHibernateSystemPropertyResolver.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2013, 2021, Oracle and/or its affiliates.
+ *
+ * Licensed under the Universal Permissive License v 1.0 as shown at
+ * https://oss.oracle.com/licenses/upl.
+ */
+package com.oracle.coherence.hibernate.cache.v53.configuration.support;
+
+import com.oracle.coherence.hibernate.cache.v53.CoherenceRegionFactory;
+import com.tangosol.coherence.config.EnvironmentVariableResolver;
+import com.tangosol.coherence.config.SystemPropertyResolver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * A Coherence {@link SystemPropertyResolver} and {@link EnvironmentVariableResolver} that uses a configurable {@link Map}
+ * to return Coherence configuration properties.
+ * <p>
+ * This class needs to be eagerly instantiated by Coherence Hibernate before any Coherence class that might need properties.
+ *
+ * @author Gunnar Hillert
+ * @since 2.1
+ */
+public class CoherenceHibernateSystemPropertyResolver
+		implements EnvironmentVariableResolver, SystemPropertyResolver  {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(CoherenceHibernateSystemPropertyResolver.class);
+
+	/**
+	 * By default empty, indicating that no Coherence property prefix is applied.
+	 */
+	public static final String DEFAULT_PROPERTY_PREFIX = CoherenceRegionFactory.PROPERTY_NAME_PREFIX + "coherence_properties.";
+
+	/**
+	 * The Coherence properties to be resolved.
+	 */
+	private static volatile Map<String, Object> coherenceProperties = new ConcurrentHashMap(0);
+
+	/**
+	 * An optional prefix. By default, not used.
+	 */
+	private static String propertyPrefix = DEFAULT_PROPERTY_PREFIX;
+
+	/**
+	 * This constructor is required so that Coherence can discover
+	 * and instantiate this class using the Java ServiceLoader.
+	 */
+	public CoherenceHibernateSystemPropertyResolver() {
+		if (LOGGER.isDebugEnabled()) {
+			LOGGER.debug("Constructing CoherenceHibernateSystemPropertyResolver.");
+		}
+	}
+
+	/**
+	 * This constructor will be called by Coherence Hibernate to instantiate the
+	 * singleton bean and set the {@link #coherenceProperties}.
+	 * @param coherenceProperties the Coherence properties. Must not be null.
+	 */
+	public CoherenceHibernateSystemPropertyResolver(Map<String, Object> coherenceProperties) {
+		this();
+		Assert.notNull(coherenceProperties, "coherenceProperties must not be null.");
+		CoherenceHibernateSystemPropertyResolver.coherenceProperties = coherenceProperties;
+
+		if (LOGGER.isDebugEnabled()) {
+			LOGGER.debug("Providing the following coherenceProperties: {}", coherenceProperties);
+		}
+	}
+
+	/**
+	 * This constructor will be called by Spring to instantiate the
+	 * singleton bean and set the {@link #coherenceProperties}.
+	 * @param coherenceProperties the Coherence properties
+	 * @param propertyPrefix must not be null. Empty String means no prefix is being used.
+	 */
+	public CoherenceHibernateSystemPropertyResolver(Map<String, Object> coherenceProperties, String propertyPrefix) {
+		this(coherenceProperties);
+		Assert.notNull(propertyPrefix, "propertyPrefix must not be null or empty.");
+		CoherenceHibernateSystemPropertyResolver.propertyPrefix = propertyPrefix;
+	}
+
+	@Override
+	public String getProperty(String coherenceProperty) {
+		if (CoherenceHibernateSystemPropertyResolver.coherenceProperties != null) {
+			final Object property = CoherenceHibernateSystemPropertyResolver.coherenceProperties.get(propertyPrefix + coherenceProperty);
+			if (property != null) {
+				if (property instanceof String) {
+					return (String) property;
+				}
+				else {
+					throw new IllegalStateException(
+							String.format("Coherence property '%s' must be an instance of String.", coherenceProperty));
+				}
+			}
+		}
+		return System.getProperty(coherenceProperty);
+	}
+
+	@Override
+	public String getEnv(String coherenceProperty) {
+		if (CoherenceHibernateSystemPropertyResolver.coherenceProperties != null) {
+			final Object property = CoherenceHibernateSystemPropertyResolver.coherenceProperties.get(propertyPrefix + coherenceProperty);
+			if (property instanceof String) {
+				return (String) property;
+			}
+			else {
+				throw new IllegalStateException(
+						String.format("Coherence property '%s' must be an instance of String.", coherenceProperty));
+			}
+		}
+		return System.getenv(coherenceProperty);
+	}
+
+	public synchronized void addCoherenceProperty(String key, String value) {
+		if (LOGGER.isDebugEnabled()) {
+			LOGGER.debug("Adding Coherence Property - key: {}, value: {}.", propertyPrefix + key, value);
+		}
+		CoherenceHibernateSystemPropertyResolver.coherenceProperties.put(propertyPrefix + key, value);
+	}
+}

--- a/coherence-hibernate-cache-53/src/main/java/com/oracle/coherence/hibernate/cache/v53/configuration/support/package-info.java
+++ b/coherence-hibernate-cache-53/src/main/java/com/oracle/coherence/hibernate/cache/v53/configuration/support/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Contains support classes.
+ */
+package com.oracle.coherence.hibernate.cache.v53.configuration.support;

--- a/coherence-hibernate-cache-53/src/main/resources/META-INF/services/com.tangosol.coherence.config.SystemPropertyResolver
+++ b/coherence-hibernate-cache-53/src/main/resources/META-INF/services/com.tangosol.coherence.config.SystemPropertyResolver
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2013, 2021, Oracle and/or its affiliates.
+#
+# Licensed under the Universal Permissive License v 1.0 as shown at
+# https://oss.oracle.com/licenses/upl.
+#
+com.oracle.coherence.hibernate.cache.v53.configuration.support.CoherenceHibernateSystemPropertyResolver

--- a/coherence-hibernate-cache-53/src/test/resources/hibernate.properties
+++ b/coherence-hibernate-cache-53/src/test/resources/hibernate.properties
@@ -15,3 +15,4 @@ hibernate.generate_statistics=true
 hibernate.cache.use_second_level_cache=true
 hibernate.cache.use_query_cache=true
 com.oracle.coherence.hibernate.cache.cache_config_file_path=tests-expiring-hibernate-second-level-cache-config.xml
+

--- a/coherence-hibernate-cache-53/src/test/resources/logback-test.xml
+++ b/coherence-hibernate-cache-53/src/test/resources/logback-test.xml
@@ -1,0 +1,16 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="Coherence" level="INFO"/>
+    <logger name="com.oracle.coherence.hibernate" level="DEBUG"/>
+    <logger name="com.oracle.coherence" level="INFO"/>
+    <logger name="org.hibernate" level="WARN"/>
+</configuration>

--- a/coherence-hibernate-site/docs/about/02_hibernate-cache.adoc
+++ b/coherence-hibernate-site/docs/about/02_hibernate-cache.adoc
@@ -333,3 +333,49 @@ Hibernate-based `CacheStores` are used.  Furthermore, second-level caches should
 the possibility of heap exhaustion.  Query caches in particular should be size-limited because the Hibernate API does
 not provide any means of controlling the query cache other than a complete eviction.  Finally, expiration should be
 considered if the underlying database can be written by clients other than the Hibernate application.
+
+=== Additional Configuration Options
+
+==== Coherence-specific properties
+
+When providing Hibernate properties, you can also specify any
+{coherence-docs}develop-applications/system-property-overrides.html#GUID-32230D28-4976-4147-A887-0A0120FF5C7E[Coherence system property overrides]
+using the following property structure:
+
+[source,properties,indent=0,subs="verbatim,quotes,attributes"]
+----
+com.oracle.coherence.hibernate.cache.coherence_properties.*=my property value
+----
+
+IMPORTANT: Specifying Coherence-specific properties is available for the Hibernate Cache 53 module only!
+
+For instance, in order to redirect the logging output of Coherence (Only Coherence!) to its own log file,
+and setting the log level to maximum, you could specify:
+
+[source,properties,indent=0,subs="verbatim,quotes,attributes"]
+----
+com.oracle.coherence.hibernate.cache.coherence_properties.coherence.log=/path/to/coherence.log
+com.oracle.coherence.hibernate.cache.coherence_properties.coherence.log.level: 9
+----
+
+==== Logging
+
+Without specifying any custom logging properties, Coherence Hibernate will set the logger of Coherence to
+`slf4j`. Therefore, Coherence Hibernate will integrate seamlessly into your application.
+
+Accordingly, Coherence Hibernate is configured using a custom implementation of Coherence' `SystemPropertyResolver`.
+
+[NOTE]
+====
+Properties defined via
+{coherence-docs}develop-applications/operational-configuration-elements.html#GUID-6DEB2F17-F6CA-4476-8EF7-2B175191929F[Operational Override Files]
+take precedence. For example, if your application provides a custom `tangosol-coherence-override.xml` file,
+such as the following, then providing a respective Coherence Hibernate property will not have any effect.
+====
+
+[source,xml,indent=0,subs="verbatim,quotes,attributes"]
+----
+<logging-config>
+    <destination>slf4j</destination>
+</logging-config>
+----

--- a/coherence-hibernate-site/sitegen.yaml
+++ b/coherence-hibernate-site/sitegen.yaml
@@ -18,6 +18,7 @@ engine:
       version-coherence: "${coherence.version}"
       timestamp: "${timestamp}"
       github-repository: "https://github.com/coherence-community/coherence-hibernate"
+      coherence-docs: "https://docs.oracle.com/en/middleware/standalone/coherence/14.1.1.0/"
 assets:
   - target: "/"
     includes:

--- a/pom.xml
+++ b/pom.xml
@@ -103,12 +103,14 @@
         <coherence.version>21.06.2</coherence.version>
         <hibernate4.version>4.3.11.Final</hibernate4.version>
         <hibernate5.version>5.1.17.Final</hibernate5.version>
-        <hibernate52.version>5.2.17.Final</hibernate52.version>
-        <hibernate53.version>5.6.0.Final</hibernate53.version>
+        <hibernate52.version>5.2.18.Final</hibernate52.version>
+        <hibernate53.version>5.6.3.Final</hibernate53.version>
         <hsqldb.version>2.2.9</hsqldb.version>
         <hsqldb.version>2.2.9</hsqldb.version>
         <junit.version>4.13.2</junit.version>
+        <logback.version>1.2.9</logback.version>
         <mockito.version>4.0.0</mockito.version>
+        <slf4j.version>1.7.32</slf4j.version>
     </properties>
 
     <distributionManagement>

--- a/samples/coherence-hibernate-demo/coherence-hibernate-demo-app/src/main/resources/tangosol-coherence-override.xml
+++ b/samples/coherence-hibernate-demo/coherence-hibernate-demo-app/src/main/resources/tangosol-coherence-override.xml
@@ -2,9 +2,9 @@
 <coherence xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns="http://xmlns.oracle.com/coherence/coherence-operational-config"
 	xsi:schemaLocation="http://xmlns.oracle.com/coherence/coherence-operational-config coherence-operational-config.xsd">
-	<logging-config>
-		<destination>slf4j</destination>
-	</logging-config>
+<!--	<logging-config>-->
+<!--		<destination>slf4j</destination>-->
+<!--	</logging-config>-->
 <!-- 	<security-config>
 		<identity-transformer>
 			<class-name>com.oracle.coherence.hibernate.demo.identity.ClientSideIdentityTransformer</class-name>


### PR DESCRIPTION
- add logback and slf4j dependency
- add logback test xml configuration
- add assertion utility class
- update Hibernate version of the `53` module to `5.6.3.Final`
- update Hibernate version of the `52` module to `5.2.18.Final`
- add CoherenceHibernateSystemPropertyResolver
- add documentation
- update logging statements

resolves #29 