### PR TITLE
bump_version_maven-surefire-plugin

### DIFF
--- a/coherence-hibernate-cache-53/pom.xml
+++ b/coherence-hibernate-cache-53/pom.xml
@@ -39,6 +39,12 @@
             <artifactId>hibernate-core-jakarta</artifactId>
             <version>${hibernate53.version}</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.bytebuddy</groupId>
+                    <artifactId>byte-buddy</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.oracle.coherence.hibernate</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
         <maven-site-plugin.version>3.21.0</maven-site-plugin.version>
         <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
-        <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
         <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
         <versions-maven-plugin>2.18.0</versions-maven-plugin>
 
@@ -184,7 +184,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire-plugin.version}</version>
                 <configuration>
-                    <argLine>@{argLine} -Xms800m -Xmx800m</argLine>
+                    <argLine>@{argLine} -Xms800m -Xmx800m -XX:+EnableDynamicAgentLoading</argLine>
                     <includes>
                         <include>**/*Test.java</include>
                         <include>**/*Tests.java</include>


### PR DESCRIPTION
Changes needed to bump maven-surefire-plugin to version 3.5.2.