### PR TITLE
Bump helidon site version from 2.2.3 to 3.0.10

### DIFF
--- a/coherence-hibernate-site/docs/about/01_overview.adoc
+++ b/coherence-hibernate-site/docs/about/01_overview.adoc
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////////
-    Copyright (c) 2013, 2021, Oracle and/or its affiliates.
+    Copyright (c) 2013, 2025, Oracle and/or its affiliates.
 
     Licensed under the Universal Permissive License v 1.0 as shown at
     https://oss.oracle.com/licenses/upl.
@@ -31,14 +31,14 @@ Complete source code together with documentation is provided via the GitHub repo
 
 [CARD]
 .Hibernate Cache
-[icon=cached,link=about/02_hibernate-cache.adoc]
+[icon=cached,link=02_hibernate-cache.adoc]
 --
 Hibernate Second Level Cache SPI
 --
 
 [CARD]
 .CacheStore
-[icon=arrow_circle_up,link=about/03_hibernate-cache-store.adoc]
+[icon=arrow_circle_up,link=03_hibernate-cache-store.adoc]
 --
 Hibernate as the implementation of a Coherence CacheStore
 --
@@ -52,7 +52,7 @@ Sample Applications.
 
 [CARD]
 .Javadocs
-[icon=code,link=api/index.html,link-type=url]
+[icon=code,link=/api/index.html,link-type=url]
 --
 Browse the Coherence Hibernate JavaDocs.
 --

--- a/coherence-hibernate-site/docs/about/02_hibernate-cache.adoc
+++ b/coherence-hibernate-site/docs/about/02_hibernate-cache.adoc
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////////
-    Copyright (c) 2013, 2022, Oracle and/or its affiliates.
+    Copyright (c) 2013, 2025, Oracle and/or its affiliates.
 
     Licensed under the Universal Permissive License v 1.0 as shown at
     https://oss.oracle.com/licenses/upl.
@@ -75,7 +75,8 @@ to your application's `pom.xml`:
 ----
 
 Alternatively, you can download `coherence-hibernate-cache-6-{version-coherence-hibernate}.jar` from a Maven repository
-(e.g. https://repo1.maven.org/maven2/) and use it in JVM classpaths. Or you can xref:dev/03_build-instructions.adoc[build]
+(e.g. https://repo1.maven.org/maven2/) and use it in JVM classpaths. Or you can 
+link:../dev/03_build-instructions.adoc[build]
 the Coherence Hibernate second-level cache implementation from sources.
 
 Coherence Hibernate depends on Oracle Coherence (E.g. https://coherence.community/[Coherence CE] (Community Edition))

--- a/coherence-hibernate-site/pom.xml
+++ b/coherence-hibernate-site/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  Copyright (c) 2013, 2024, Oracle and/or its affiliates.
+  Copyright (c) 2013, 2025, Oracle and/or its affiliates.
   Licensed under the Universal Permissive License v 1.0 as shown at
   https://oss.oracle.com/licenses/upl.
 -->
@@ -26,7 +26,7 @@
         <maven.build.timestamp.format>yyyy-MM-dd HH:mm</maven.build.timestamp.format>
         <timestamp>${maven.build.timestamp}</timestamp>
         <coherence.hibernate.root>${basedir}/..</coherence.hibernate.root>
-        <helidon.sitegen.version>2.2.3</helidon.sitegen.version>
+        <helidon.sitegen.version>3.0.10</helidon.sitegen.version>
         <asciidoctor-diagram.version>2.3.1</asciidoctor-diagram.version>
         <doxia.version>2.0.0</doxia.version>
         <maven-dependency-plugin.version>3.1.2</maven-dependency-plugin.version>

--- a/coherence-hibernate-site/sitegen.yaml
+++ b/coherence-hibernate-site/sitegen.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2025, Oracle and/or its affiliates. All rights reserved.
 # Licensed under the Universal Permissive License v 1.0 as shown at
 # https://oss.oracle.com/licenses/upl.
 
@@ -48,67 +48,90 @@ backend:
     releases:
         - "${project.version}"
     navigation:
+      type: "ROOT"
       title: "Oracle Coherence Hibernate"
       glyph:
         type: "image"
         value: "images/logo.png"
       items:
-        - title: "Project Website"
-          pathprefix: "/about"
+        - type: "GROUPS"
           items:
-            - title: "Getting Started"
+            - type: "GROUP"
+              title: "Project Website"
               pathprefix: "/about"
-              glyph:
-                type: "icon"
-                value: "assistant"
               items:
-                - includes:
-                    - "about/*.adoc"
-            - title: "Development"
-              pathprefix: "/dev"
-              glyph:
-                type: "icon"
-                value: "fa-code"
+                - type: "MENU"
+                  title: "Getting Started"
+                  dir: "about"
+                  pathprefix: "/about"
+                  glyph:
+                    type: "icon"
+                    value: "assistant"
+                  sources:
+                    - 01_overview.adoc
+                    - 02_hibernate-cache.adoc
+                    - 03_hibernate-cache-store.adoc
+                - type: "MENU"
+                  title: "Development"
+                  dir: "dev"
+                  pathprefix: "/dev"
+                  glyph:
+                    type: "icon"
+                    value: "fa-code"
+                  sources:
+                    - 01_license.adoc
+                    - 02_source-code.adoc
+                    - 03_build-instructions.adoc
+                    - 04_issue-tracking.adoc
+                    - 05_contributions.adoc
+                    - 06_history.adoc
+                    - 07_getting-help.adoc
+            - type: "GROUP"
+              title: "Reference Documentation"
+              pathprefix: "/docs"
               items:
-                - includes:
-                    - "dev/*.adoc"
-        - title: "Reference Documentation"
-          pathprefix: "/docs"
-          items:
-            - title: "Javadocs"
-              glyph:
-                type: "icon"
-                value: "code"
-              href: "api/index.html"
-        - title: "Additional Resources"
-          items:
-            - title: "Slack"
-              glyph:
-                type: "icon"
-                value: "fa-slack"
-              href: "https://join.slack.com/t/oraclecoherence/shared_invite/enQtNzcxNTQwMTAzNjE4LTJkZWI5ZDkzNGEzOTllZDgwZDU3NGM2YjY5YWYwMzM3ODdkNTU2NmNmNDFhOWIxMDZlNjg2MzE3NmMxZWMxMWE"
-            - title: "Coherence Web Site"
-              glyph:
-                type: "icon"
-                value: "fa-globe"
-              href: "https://coherence.community/"
-            - title: "Coherence Spring"
-              glyph:
-                type: "icon"
-                value: "fa-globe"
-              href: "https://spring.coherence.community/"
-            - title: "Micronaut Coherence"
-              glyph:
-                type: "icon"
-                value: "fa-globe"
-              href: "https://github.com/micronaut-projects/micronaut-coherence/"
-            - title: "GitHub"
-              glyph:
-                type: "icon"
-                value: "fa-github-square"
-              href: "https://github.com/coherence-community/coherence-hibernate/"
-            - title: "Twitter"
-              glyph:
-                type: "icon"
-                value: "fa-twitter-square"
-              href: "https://twitter.com/OracleCoherence/"
+                - type: "LINK"
+                  title: "Javadocs"
+                  glyph:
+                    type: "icon"
+                    value: "code"
+                  href: "api/index.html"
+            - type: "GROUP"
+              title: "Additional Resources"
+              items:
+                - type: "LINK"
+                  title: "Slack"
+                  glyph:
+                    type: "icon"
+                    value: "fa-slack"
+                  href: "https://join.slack.com/t/oraclecoherence/shared_invite/enQtNzcxNTQwMTAzNjE4LTJkZWI5ZDkzNGEzOTllZDgwZDU3NGM2YjY5YWYwMzM3ODdkNTU2NmNmNDFhOWIxMDZlNjg2MzE3NmMxZWMxMWE"
+                - type: "LINK"
+                  title: "Coherence Web Site"
+                  glyph:
+                    type: "icon"
+                    value: "fa-globe"
+                  href: "https://coherence.community/"
+                - type: "LINK"
+                  title: "Coherence Spring"
+                  glyph:
+                    type: "icon"
+                    value: "fa-globe"
+                  href: "https://spring.coherence.community/"
+                - type: "LINK"
+                  title: "Micronaut Coherence"
+                  glyph:
+                    type: "icon"
+                    value: "fa-globe"
+                  href: "https://github.com/micronaut-projects/micronaut-coherence/"
+                - type: "LINK"
+                  title: "GitHub"
+                  glyph:
+                    type: "icon"
+                    value: "fa-github-square"
+                  href: "https://github.com/coherence-community/coherence-hibernate/"
+                - type: "LINK"
+                  title: "Twitter"
+                  glyph:
+                    type: "icon"
+                    value: "fa-twitter-square"
+                  href: "https://twitter.com/OracleCoherence/"

--- a/src/main/config/dependency-check-suppression.xml
+++ b/src/main/config/dependency-check-suppression.xml
@@ -7,4 +7,11 @@
         <packageUrl regex="true">^pkg:maven/org\.xmlunit/xmlunit-core@.*$</packageUrl>
         <vulnerabilityName>CVE-2024-31573</vulnerabilityName>
     </suppress>
+    <suppress until="2025-04-01Z">
+        <notes><![CDATA[
+        file name: json-smart-2.5.1.jar
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/net.minidev/json-smart@.*$</packageUrl>
+        <vulnerabilityName>CVE-2024-57699</vulnerabilityName>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
Motivated by failed Dependabot pull request for Bump io.helidon.build-tools:sitegen-maven-plugin from 2.2.3 to 3.0.10.
The sitegen.yaml has to be upgraded to specify -type ROOT|GROUPS|GROUP|MENU....
Additionally, *.adoc references had to be fixed.